### PR TITLE
Fargate版のCloudFormationテンプレートと運用スクリプトを追加

### DIFF
--- a/aws/fargate.yaml
+++ b/aws/fargate.yaml
@@ -1,0 +1,408 @@
+AWSTemplateFormatVersion: 2010-09-09
+
+Description: >
+  asobann on ECS Fargate.
+  ADR 0004 に基づき、ECS on EC2 から Fargate へ移行するための構成。
+  MongoDB は Atlas を使うため、このスタックはデータストアを持たない（ADR 0003）。
+  Route53レコードとACM証明書は別アカウントのホストゾーンに関わるため、このスタックの外で扱う。
+
+Parameters:
+  PublicHostname:
+    Type: String
+    Description: このスタックが応答するホスト名。切り替え前は next.asobann.yattom.jp 等、切り替え時に asobann.yattom.jp へ変更する
+
+  CertificateArn:
+    Type: String
+    Description: ALBに設定するACM証明書。このアカウント・このリージョンに存在すること
+
+  AppImage:
+    Type: String
+    Description: アプリのコンテナイメージURI
+
+  MongoDbUriParameterName:
+    Type: String
+    Default: /asobann/prod/mongodb_uri
+    Description: MongoDB接続文字列を格納したSSMパラメータ名（SecureString）
+
+  AppTaskCount:
+    Type: Number
+    Default: 1
+    Description: タスク数。1ならRedis不要でスティッキーセッションも実質不要（ADR 0004）
+
+  TaskCpu:
+    Type: String
+    Default: 256
+
+  TaskMemory:
+    Type: String
+    Default: 512
+
+  GoogleAnalyticsId:
+    Type: String
+    Default: ''
+
+
+Resources:
+
+  # ---------------------------------------------------------------- ネットワーク
+  # NAT Gatewayを置かず、タスクをパブリックサブネットに直接配置する。
+  # ECRとAtlasへの通信はInternet Gateway経由。NAT Gateway代（月$30〜40）を避けるため。
+
+  Vpc:
+    Type: AWS::EC2::VPC
+    Properties:
+      CidrBlock: 10.1.0.0/16
+      EnableDnsHostnames: true
+      EnableDnsSupport: true
+      Tags:
+        - Key: Name
+          Value: !Sub ${AWS::StackName}-vpc
+
+  InternetGateway:
+    Type: AWS::EC2::InternetGateway
+
+  InternetGatewayAttachment:
+    Type: AWS::EC2::VPCGatewayAttachment
+    Properties:
+      VpcId: !Ref Vpc
+      InternetGatewayId: !Ref InternetGateway
+
+  PublicSubnet1:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref Vpc
+      CidrBlock: 10.1.0.0/24
+      AvailabilityZone: !Select [0, !GetAZs '']
+      MapPublicIpOnLaunch: true
+
+  PublicSubnet2:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref Vpc
+      CidrBlock: 10.1.1.0/24
+      AvailabilityZone: !Select [1, !GetAZs '']
+      MapPublicIpOnLaunch: true
+
+  RouteTable:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref Vpc
+
+  DefaultRoute:
+    Type: AWS::EC2::Route
+    DependsOn: InternetGatewayAttachment
+    Properties:
+      RouteTableId: !Ref RouteTable
+      DestinationCidrBlock: 0.0.0.0/0
+      GatewayId: !Ref InternetGateway
+
+  PublicSubnet1RouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      RouteTableId: !Ref RouteTable
+      SubnetId: !Ref PublicSubnet1
+
+  PublicSubnet2RouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      RouteTableId: !Ref RouteTable
+      SubnetId: !Ref PublicSubnet2
+
+  # ---------------------------------------------------------------- セキュリティグループ
+
+  LoadBalancerSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: asobann load balancer
+      VpcId: !Ref Vpc
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: 80
+          ToPort: 80
+          CidrIp: 0.0.0.0/0
+          Description: http (redirects to https)
+        - IpProtocol: tcp
+          FromPort: 443
+          ToPort: 443
+          CidrIp: 0.0.0.0/0
+          Description: https
+
+  TaskSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: asobann app tasks
+      VpcId: !Ref Vpc
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: 5000
+          ToPort: 5000
+          SourceSecurityGroupId: !Ref LoadBalancerSecurityGroup
+          Description: from load balancer only
+
+  # ---------------------------------------------------------------- ロードバランサ
+
+  LoadBalancer:
+    Type: AWS::ElasticLoadBalancingV2::LoadBalancer
+    Properties:
+      Type: application
+      Scheme: internet-facing
+      Subnets:
+        - !Ref PublicSubnet1
+        - !Ref PublicSubnet2
+      SecurityGroups:
+        - !Ref LoadBalancerSecurityGroup
+      LoadBalancerAttributes:
+        # socket.ioのping間隔は25秒。既定の60秒でも足りるが、依存を明示するため設定する
+        - Key: idle_timeout.timeout_seconds
+          Value: 120
+
+  TargetGroup:
+    Type: AWS::ElasticLoadBalancingV2::TargetGroup
+    DependsOn: LoadBalancer
+    Properties:
+      VpcId: !Ref Vpc
+      Port: 5000
+      Protocol: HTTP
+      # Fargateはawsvpcネットワークモードのため instance ではなく ip
+      TargetType: ip
+      HealthCheckPath: /
+      HealthCheckProtocol: HTTP
+      HealthCheckIntervalSeconds: 30
+      HealthCheckTimeoutSeconds: 5
+      HealthyThresholdCount: 2
+      UnhealthyThresholdCount: 3
+      # トップページは新規テーブルへ302リダイレクトするため 200 だけでは不合格になる
+      Matcher:
+        HttpCode: 200-399
+      TargetGroupAttributes:
+        - Key: deregistration_delay.timeout_seconds
+          Value: 30
+        # 1タスクなら実質不要だが、タスクを増やしたときにsocket.ioのハンドシェイクが
+        # 破綻しないよう有効にしておく（pollingで握手してからwebsocketへ上がるため）
+        - Key: stickiness.enabled
+          Value: true
+        - Key: stickiness.type
+          Value: lb_cookie
+
+  HttpListener:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    Properties:
+      LoadBalancerArn: !Ref LoadBalancer
+      Port: 80
+      Protocol: HTTP
+      DefaultActions:
+        - Type: redirect
+          RedirectConfig:
+            Protocol: HTTPS
+            Port: 443
+            StatusCode: HTTP_301
+
+  HttpsListener:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    Properties:
+      LoadBalancerArn: !Ref LoadBalancer
+      Port: 443
+      Protocol: HTTPS
+      Certificates:
+        - CertificateArn: !Ref CertificateArn
+      SslPolicy: ELBSecurityPolicy-TLS13-1-2-2021-06
+      DefaultActions:
+        - Type: forward
+          TargetGroupArn: !Ref TargetGroup
+
+  # ---------------------------------------------------------------- 画像アップロード先
+  # 2023年4月以降に作られるバケットは既定でACLが無効。アプリは public-read ACL を
+  # 付けてアップロードするため、明示的にACLを有効化する必要がある。
+  # （アプリ側を直すのが本筋だが、ADR 0002によりイメージは変更しない）
+
+  ImageBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      OwnershipControls:
+        Rules:
+          - ObjectOwnership: ObjectWriter
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: false
+        IgnorePublicAcls: false
+        BlockPublicPolicy: true
+        RestrictPublicBuckets: false
+      CorsConfiguration:
+        CorsRules:
+          - AllowedMethods: [GET]
+            AllowedOrigins: ['*']
+            AllowedHeaders: ['*']
+
+  # ---------------------------------------------------------------- IAM
+  # 実行ロール: ECSがイメージを引き、ログを書き、シークレットを読むために使う
+  # タスクロール: アプリ自身がS3を触るために使う
+
+  TaskExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: ecs-tasks.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy
+      Policies:
+        - PolicyName: read-secrets
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action: ssm:GetParameters
+                Resource: !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter${MongoDbUriParameterName}
+
+  TaskRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: ecs-tasks.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: image-bucket-access
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                  - s3:PutObject
+                  - s3:PutObjectAcl
+                  - s3:GetObject
+                Resource: !Sub ${ImageBucket.Arn}/*
+        # 旧構成ではEC2ホストへ入る手段が全滅し（SSH鍵紛失、EC2 Instance ConnectとSSMは
+        # エージェント未導入）、DBのダンプ取得にセキュリティグループの一時開放が必要になった。
+        # 同じ轍を踏まないよう、最初からECS Execでコンテナに入れるようにしておく。
+        #   aws ecs execute-command --cluster <name> --task <id> --container app --interactive --command /bin/bash
+        - PolicyName: ecs-exec
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                  - ssmmessages:CreateControlChannel
+                  - ssmmessages:CreateDataChannel
+                  - ssmmessages:OpenControlChannel
+                  - ssmmessages:OpenDataChannel
+                Resource: '*'
+
+  LogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub /ecs/${AWS::StackName}
+      RetentionInDays: 30
+
+  # ---------------------------------------------------------------- ECS
+
+  Cluster:
+    Type: AWS::ECS::Cluster
+    Properties:
+      ClusterName: !Ref AWS::StackName
+
+  TaskDefinition:
+    Type: AWS::ECS::TaskDefinition
+    Properties:
+      Family: !Sub ${AWS::StackName}-app
+      RequiresCompatibilities:
+        - FARGATE
+      NetworkMode: awsvpc
+      Cpu: !Ref TaskCpu
+      Memory: !Ref TaskMemory
+      ExecutionRoleArn: !GetAtt TaskExecutionRole.Arn
+      TaskRoleArn: !GetAtt TaskRole.Arn
+      ContainerDefinitions:
+        - Name: app
+          Image: !Ref AppImage
+          Essential: true
+          # イメージのCMDは `python3 -m asobann.deploy ; python3 -m asobann.wsgi` で、
+          # 起動のたびにキット初期化がDBを上書きし、イメージに無いキットを消してしまう。
+          # 初期化を実行しないよう上書きする（ADR 0007）
+          Command:
+            - python3
+            - -m
+            - asobann.wsgi
+          PortMappings:
+            - ContainerPort: 5000
+              Protocol: tcp
+          Environment:
+            - Name: PUBLIC_HOSTNAME
+              Value: !Ref PublicHostname
+            - Name: FLASK_ENV
+              Value: production
+            - Name: GOOGLE_ANALYTICS_ID
+              Value: !Ref GoogleAnalyticsId
+            - Name: UPLOADED_IMAGE_STORE
+              Value: s3
+            - Name: AWS_REGION
+              Value: !Ref AWS::Region
+            - Name: AWS_S3_IMAGE_BUCKET_NAME
+              Value: !Ref ImageBucket
+            # config_common.py は UPLOADED_IMAGE_STORE=s3 のとき AWS_KEY / AWS_SECRET を必須にする。
+            # 空文字を渡すと boto3 は明示指定とみなさず既定の認証チェーンにフォールバックし、
+            # タスクロールが使われる（イメージ内で実測確認済み）。静的キーを持たずに済む
+            - Name: AWS_KEY
+              Value: ''
+            - Name: AWS_SECRET
+              Value: ''
+          Secrets:
+            - Name: MONGODB_URI
+              ValueFrom: !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter${MongoDbUriParameterName}
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-region: !Ref AWS::Region
+              awslogs-group: !Ref LogGroup
+              awslogs-stream-prefix: app
+
+  Service:
+    Type: AWS::ECS::Service
+    DependsOn: HttpsListener
+    Properties:
+      Cluster: !Ref Cluster
+      LaunchType: FARGATE
+      PlatformVersion: LATEST
+      DesiredCount: !Ref AppTaskCount
+      TaskDefinition: !Ref TaskDefinition
+      EnableExecuteCommand: true
+      HealthCheckGracePeriodSeconds: 60
+      DeploymentConfiguration:
+        MinimumHealthyPercent: 0
+        MaximumPercent: 200
+      NetworkConfiguration:
+        AwsvpcConfiguration:
+          # NAT Gatewayを置かないため、パブリックIPを付けてIGW経由で外に出る
+          AssignPublicIp: ENABLED
+          Subnets:
+            - !Ref PublicSubnet1
+            - !Ref PublicSubnet2
+          SecurityGroups:
+            - !Ref TaskSecurityGroup
+      LoadBalancers:
+        - ContainerName: app
+          ContainerPort: 5000
+          TargetGroupArn: !Ref TargetGroup
+
+
+Outputs:
+  LoadBalancerDnsName:
+    Description: Route53のALIASレコードの向き先に指定する値
+    Value: !GetAtt LoadBalancer.DNSName
+
+  LoadBalancerHostedZoneId:
+    Description: ALIASレコード作成時に必要なホストゾーンID
+    Value: !GetAtt LoadBalancer.CanonicalHostedZoneID
+
+  ImageBucketName:
+    Description: 旧アカウントのバケットから中身を同期する先
+    Value: !Ref ImageBucket
+
+  ClusterName:
+    Value: !Ref Cluster

--- a/aws/fargate.yaml
+++ b/aws/fargate.yaml
@@ -6,6 +6,11 @@ Description: >
   MongoDB は Atlas を使うため、このスタックはデータストアを持たない（ADR 0003）。
   Route53レコードとACM証明書は別アカウントのホストゾーンに関わるため、このスタックの外で扱う。
 
+  デプロイ例（タグはスタック単位で付けると対応リソースへ自動で伝播する）:
+    aws cloudformation deploy --template-file aws/fargate.yaml --stack-name asobann-fargate \
+      --capabilities CAPABILITY_IAM --tags Project=asobann Env=prod \
+      --parameter-overrides PublicHostname=... CertificateArn=... AppImage=...
+
 Parameters:
   PublicHostname:
     Type: String
@@ -22,6 +27,9 @@ Parameters:
   MongoDbUriParameterName:
     Type: String
     Default: /asobann/prod/mongodb_uri
+    # 先頭の / を前提にARNを組み立てるため、形式を強制する
+    AllowedPattern: ^/.+
+    ConstraintDescription: /で始まるSSMパラメータ名を指定すること
     Description: MongoDB接続文字列を格納したSSMパラメータ名（SecureString）
 
   AppTaskCount:
@@ -165,6 +173,10 @@ Resources:
       Protocol: HTTP
       # Fargateはawsvpcネットワークモードのため instance ではなく ip
       TargetType: ip
+      # 注意: / はテーブル名を乱数生成してリダイレクトするだけでDBに触れない。
+      # ゴミテーブルは作られない代わりに、MongoDBが落ちてもこのチェックは通り続ける。
+      # DBの死活はこのヘルスチェックでは検知できないため、別途監視が必要。
+      # （アプリ側に疎通用エンドポイントが無く、イメージを変更しない方針のため）
       HealthCheckPath: /
       HealthCheckProtocol: HTTP
       HealthCheckIntervalSeconds: 30
@@ -217,6 +229,10 @@ Resources:
 
   ImageBucket:
     Type: AWS::S3::Bucket
+    # このスタックで唯一の永続データ（ユーザがアップロードした画像）が入る。
+    # スタック削除や置換で消えないよう明示的に残す。
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Properties:
       OwnershipControls:
         Rules:
@@ -249,6 +265,10 @@ Resources:
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy
       Policies:
+        # SecureStringの復号にkms:Decryptは要らない。AWS管理キー(alias/aws/ssm)の
+        # キーポリシーが kms:ViaService でアカウント内のSSM経由の復号を許可するため。
+        # 実際にこの権限だけでタスクが起動しシークレットを取得できることを確認済み。
+        # カスタマー管理キーに切り替える場合は kms:Decrypt の追加が必要になる。
         - PolicyName: read-secrets
           PolicyDocument:
             Version: 2012-10-17

--- a/aws/templates/cluster.yaml
+++ b/aws/templates/cluster.yaml
@@ -155,7 +155,7 @@ Resources:
                   - /etc/cfn/cfn-hup.conf
                   - /etc/cfn/hooks.d/cfn-auto-reloader.conf
     Properties:
-      ImageId: ami-007cd1678c6286a05
+      ImageId: ami-03dbf0c122cb6cf1d
       InstanceType: !Ref InstanceType
       KeyName: asobann_aws
       IamInstanceProfile: !Ref InstanceProfile

--- a/aws/templates/service/app.yaml
+++ b/aws/templates/service/app.yaml
@@ -100,25 +100,25 @@ Resources:
               Value: redis+srv://redis.asobann-internal.yattom.jp
             - Name: PUBLIC_HOSTNAME
               Value: !Ref PublicHostname
-            - NAME: GOOGLE_ANALYTICS_ID
+            - Name: GOOGLE_ANALYTICS_ID
               Value: !Ref GoogleAnalyticsId
-            - NAME: UPLOADED_IMAGE_STORE
+            - Name: UPLOADED_IMAGE_STORE
               Value: !Ref UploadedImageStore
-            - NAME: AWS_KEY
+            - Name: AWS_KEY
               Value: !Ref AwsKey
-            - NAME: AWS_SECRET
+            - Name: AWS_SECRET
               Value: !Ref AwsSecret
-            - NAME: AWS_REGION
+            - Name: AWS_REGION
               Value: !Ref AWS::Region
-            - NAME: AWS_S3_IMAGE_BUCKET_NAME
+            - Name: AWS_S3_IMAGE_BUCKET_NAME
               Value: !Ref ImageBucket
-            - NAME: AWS_COGNITO_USER_POOL_ID
+            - Name: AWS_COGNITO_USER_POOL_ID
               Value: !Ref AwsCognitoUserPoolId
-            - NAME: AWS_COGNITO_CLIENT_ID
+            - Name: AWS_COGNITO_CLIENT_ID
               Value: !Ref AwsCognitoClientId
-            - NAME: FLASK_ENV
+            - Name: FLASK_ENV
               Value: !Ref FlaskEnv
-            - NAME: ASOBANN_DEBUG_OPTS
+            - Name: ASOBANN_DEBUG_OPTS
               Value: !Ref DebugOpts
           LogConfiguration:
             LogDriver: awslogs

--- a/aws/templates/service/mongodb.yaml
+++ b/aws/templates/service/mongodb.yaml
@@ -48,7 +48,7 @@ Resources:
       ExecutionRoleArn: !Ref TaskExecutionRole
       ContainerDefinitions:
         - Name: mongodb-container
-          Image: mongo:latest
+          Image: mongo:5
           Essential: true
           PortMappings:
             - Protocol: tcp
@@ -72,7 +72,7 @@ Resources:
         - Name: !Sub mongodb-data-${AsobannEnv}
           DockerVolumeConfiguration:
             Scope: shared
-            AutoProvision: true
+            Autoprovision: true
             Driver: rexray/ebs
             DriverOpts:
               volumetype: gp2

--- a/tools/dump_mongodb.sh
+++ b/tools/dump_mongodb.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+#
+# 本番MongoDBのダンプを取得する。
+#
+# 本番EC2にはシェルで入れない（SSH秘密鍵を紛失、EC2 Instance ConnectとSSMは
+# ECS-optimized AMIにエージェントが無く利用不可）。そのため、mongoコンテナが
+# バインドされているEC2ホストの動的ポートに対して、実行元のIPからだけ一時的に
+# セキュリティグループを開け、mongodumpし、終了時に必ず閉じる。
+#
+# 前提: aws cli（本番スタックを読める権限）、docker
+#       ローカルにmongodumpは不要（コンテナで実行する）
+#
+# 使い方:
+#   ./dump_mongodb.sh [出力ディレクトリ]
+#
+# 取得したダンプの検証:
+#   docker run -d --name mongo-verify -p 27018:27017 mongo:5
+#   docker run --rm --network host -v "$PWD:/in" mongo:5 \
+#     mongorestore --host localhost:27018 --archive=/in/<file> --gzip --nsInclude 'asobann_dev.*'
+#   docker rm -f mongo-verify
+
+set -euo pipefail
+
+STACK=${STACK:-asobann-prod}
+CLUSTER=${CLUSTER:-asobann-prod-Cluster-7YBO3O7SWITB}
+TASK_FAMILY=${TASK_FAMILY:-mongodb}
+MONGO_IMAGE=${MONGO_IMAGE:-mongo:5}
+MONGO_USER=${MONGO_USER:-admin}
+OUTDIR=${1:-$(pwd)}
+
+ARCHIVE="$OUTDIR/asobann-$(date +%Y%m%d-%H%M%S).gz"
+
+echo "==> 対象を特定する"
+
+# mongoタスクのhostPortは動的割り当てのため、タスク再起動のたびに変わる。毎回引き直す。
+task_arn=$(aws ecs list-tasks --cluster "$CLUSTER" --family "$TASK_FAMILY" \
+  --desired-status RUNNING --query 'taskArns[0]' --output text)
+[ "$task_arn" = "None" ] && { echo "mongoタスクが見つからない" >&2; exit 1; }
+
+host_port=$(aws ecs describe-tasks --cluster "$CLUSTER" --tasks "$task_arn" \
+  --query 'tasks[0].containers[0].networkBindings[0].hostPort' --output text)
+
+container_arn=$(aws ecs describe-tasks --cluster "$CLUSTER" --tasks "$task_arn" \
+  --query 'tasks[0].containerInstanceArn' --output text)
+instance_id=$(aws ecs describe-container-instances --cluster "$CLUSTER" \
+  --container-instances "$container_arn" --query 'containerInstances[0].ec2InstanceId' --output text)
+
+read -r public_ip sg_ids <<<"$(aws ec2 describe-instances --instance-ids "$instance_id" \
+  --query 'Reservations[0].Instances[0].[PublicIpAddress, join(`,`, SecurityGroups[].GroupId)]' \
+  --output text)"
+
+# SGが複数あるとどれを開ければよいか一意に決まらないので、その場合は手動対応にする
+case "$sg_ids" in
+  *,*) echo "セキュリティグループが複数ある($sg_ids)。手動で確認すること" >&2; exit 1 ;;
+esac
+
+my_ip=$(curl -s --max-time 10 https://checkip.amazonaws.com)
+
+echo "    instance : $instance_id ($public_ip)"
+echo "    hostPort : $host_port"
+echo "    SG       : $sg_ids"
+echo "    自分のIP : $my_ip"
+
+# 開けたルールは何があっても閉じる
+revoke() {
+  echo "==> セキュリティグループのルールを削除する"
+  if aws ec2 revoke-security-group-ingress --group-id "$sg_ids" \
+       --ip-permissions "IpProtocol=tcp,FromPort=${host_port},ToPort=${host_port},IpRanges=[{CidrIp=${my_ip}/32}]" \
+       >/dev/null 2>&1; then
+    echo "    削除した"
+  else
+    echo "    削除に失敗した。手動で確認すること: aws ec2 describe-security-groups --group-ids $sg_ids" >&2
+  fi
+}
+trap revoke EXIT
+
+echo "==> tcp/${host_port} を ${my_ip}/32 にだけ開ける"
+aws ec2 authorize-security-group-ingress --group-id "$sg_ids" \
+  --ip-permissions "IpProtocol=tcp,FromPort=${host_port},ToPort=${host_port},IpRanges=[{CidrIp=${my_ip}/32,Description='temporary mongodump access'}]" \
+  --query 'SecurityGroupRules[].SecurityGroupRuleId' --output text
+
+# パスワードはCloudFormationのパラメータに平文で入っている（NoEcho未設定）。
+# 引数に渡すとホストのプロセス一覧に出るので、環境変数で受け渡す。
+export PW
+PW=$(aws cloudformation describe-stacks --stack-name "$STACK" \
+  --query 'Stacks[0].Parameters[?ParameterKey==`MongoDbPassword`].ParameterValue' --output text)
+
+echo "==> mongodump"
+mkdir -p "$OUTDIR"
+docker run --rm --user "$(id -u):$(id -g)" -e PW -v "$OUTDIR:/out" "$MONGO_IMAGE" \
+  sh -c "mongodump --host ${public_ip}:${host_port} -u ${MONGO_USER} -p \"\$PW\" \
+         --authenticationDatabase admin --archive=/out/$(basename "$ARCHIVE") --gzip"
+
+echo "==> 完了: $ARCHIVE"
+ls -lh "$ARCHIVE"

--- a/tools/dump_mongodb.sh
+++ b/tools/dump_mongodb.sh
@@ -30,6 +30,10 @@ OUTDIR=${1:-$(pwd)}
 
 ARCHIVE="$OUTDIR/asobann-$(date +%Y%m%d-%H%M%S).gz"
 
+# 出力先の準備はセキュリティグループを開ける前に済ませる。書けないディレクトリを
+# 指定していた場合に、穴を開けてから失敗するのを避けるため。
+mkdir -p "$OUTDIR"
+
 echo "==> 対象を特定する"
 
 # mongoタスクのhostPortは動的割り当てのため、タスク再起動のたびに変わる。毎回引き直す。
@@ -51,18 +55,30 @@ read -r public_ip sg_ids <<<"$(aws ec2 describe-instances --instance-ids "$insta
 
 # SGが複数あるとどれを開ければよいか一意に決まらないので、その場合は手動対応にする
 case "$sg_ids" in
-  *,*) echo "セキュリティグループが複数ある($sg_ids)。手動で確認すること" >&2; exit 1 ;;
+  '' | None) echo "セキュリティグループを特定できなかった" >&2; exit 1 ;;
+  *,*)       echo "セキュリティグループが複数ある($sg_ids)。手動で確認すること" >&2; exit 1 ;;
+esac
+
+# パブリックIPが無いインスタンスには手元から到達できない。ここで止めないと
+# mongodumpが分かりにくい接続エラーで落ちる。
+case "$public_ip" in
+  '' | None) echo "インスタンスにパブリックIPが無いため到達できない" >&2; exit 1 ;;
 esac
 
 my_ip=$(curl -s --max-time 10 https://checkip.amazonaws.com)
+[ -n "$my_ip" ] || { echo "自分のグローバルIPを取得できなかった" >&2; exit 1; }
 
 echo "    instance : $instance_id ($public_ip)"
 echo "    hostPort : $host_port"
 echo "    SG       : $sg_ids"
 echo "    自分のIP : $my_ip"
 
-# 開けたルールは何があっても閉じる
+# 開けたルールは何があっても閉じる。
+# authorizeが失敗した場合まで「削除に失敗した」と警告すると、開いていないのに
+# 手動確認を促すことになるので、開けたときだけ閉じる。
+opened=no
 revoke() {
+  [ "$opened" = yes ] || return 0
   echo "==> セキュリティグループのルールを削除する"
   if aws ec2 revoke-security-group-ingress --group-id "$sg_ids" \
        --ip-permissions "IpProtocol=tcp,FromPort=${host_port},ToPort=${host_port},IpRanges=[{CidrIp=${my_ip}/32}]" \
@@ -78,6 +94,7 @@ echo "==> tcp/${host_port} を ${my_ip}/32 にだけ開ける"
 aws ec2 authorize-security-group-ingress --group-id "$sg_ids" \
   --ip-permissions "IpProtocol=tcp,FromPort=${host_port},ToPort=${host_port},IpRanges=[{CidrIp=${my_ip}/32,Description='temporary mongodump access'}]" \
   --query 'SecurityGroupRules[].SecurityGroupRuleId' --output text
+opened=yes
 
 # パスワードはCloudFormationのパラメータに平文で入っている（NoEcho未設定）。
 # 引数に渡すとホストのプロセス一覧に出るので、環境変数で受け渡す。
@@ -86,10 +103,9 @@ PW=$(aws cloudformation describe-stacks --stack-name "$STACK" \
   --query 'Stacks[0].Parameters[?ParameterKey==`MongoDbPassword`].ParameterValue' --output text)
 
 echo "==> mongodump"
-mkdir -p "$OUTDIR"
 docker run --rm --user "$(id -u):$(id -g)" -e PW -v "$OUTDIR:/out" "$MONGO_IMAGE" \
-  sh -c "mongodump --host ${public_ip}:${host_port} -u ${MONGO_USER} -p \"\$PW\" \
-         --authenticationDatabase admin --archive=/out/$(basename "$ARCHIVE") --gzip"
+  sh -c "mongodump --host \"${public_ip}:${host_port}\" -u \"${MONGO_USER}\" -p \"\$PW\" \
+         --authenticationDatabase admin --archive=\"/out/$(basename "$ARCHIVE")\" --gzip"
 
 echo "==> 完了: $ARCHIVE"
 ls -lh "$ARCHIVE"

--- a/tools/rewrite_image_urls.js
+++ b/tools/rewrite_image_urls.js
@@ -7,11 +7,18 @@
 // 最終ダンプをリストアするとデータが元に戻るので、カットオーバー時にも再実行すること。
 //
 // 使い方:
-//   mongosh "<uri>" --file rewrite_image_urls.js --eval 'var OLD="旧バケット名", NEW="新バケット名"'
+//   mongosh "<uri>" --file rewrite_image_urls.js \
+//     --eval 'var OLD="旧バケット名", NEW="新バケット名"'
+//
+// 書き換えずに件数だけ確認する（本番に流す前に必ず一度実行すること）:
+//   mongosh "<uri>" --file rewrite_image_urls.js \
+//     --eval 'var OLD="...", NEW="...", DRY=true'
 
 if (typeof OLD === 'undefined' || typeof NEW === 'undefined') {
     throw new Error('OLD と NEW を --eval で指定すること');
 }
+
+const DRY_RUN = typeof DRY !== 'undefined' && DRY;
 
 // Extended JSONへの往復で置換する。ObjectIdやDate等のBSON型は $oid / $date 表現に
 // なるため、単純な文字列置換をしても型が壊れない。
@@ -19,37 +26,47 @@ if (typeof OLD === 'undefined' || typeof NEW === 'undefined') {
 // 再帰的に走査して文字列の葉だけを置き換える方法は使わないこと。mongoshのBSON
 // デシリアライザは別realmのオブジェクトを返すため `value.constructor === Object`
 // による埋め込みドキュメントの判定が常にfalseになり、置換が実行されない。
-function replaceInDocument(doc) {
-    const canonical = EJSON.stringify(doc, null, 0, {relaxed: false});
-    return EJSON.parse(canonical.split(OLD).join(NEW));
+function serialize(doc) {
+    return EJSON.stringify(doc, null, 0, {relaxed: false});
 }
 
 const collections = ['tables', 'table_metas', 'components', 'kits'];
 let total = 0;
 
+if (DRY_RUN) {
+    print('dry-run: 件数を数えるだけで書き換えは行わない');
+}
+
 collections.forEach(name => {
     const collection = db.getCollection(name);
     let count = 0;
     collection.find({}).forEach(doc => {
-        if (EJSON.stringify(doc).indexOf(OLD) === -1) {
+        // 判定と置換で同じシリアライズ結果を使い回す
+        const canonical = serialize(doc);
+        if (canonical.indexOf(OLD) === -1) {
             return;
         }
-        collection.replaceOne({_id: doc._id}, replaceInDocument(doc));
+        if (!DRY_RUN) {
+            collection.replaceOne({_id: doc._id}, EJSON.parse(canonical.split(OLD).join(NEW)));
+        }
         count++;
     });
-    print(`${name}: ${count} 件を書き換え`);
+    print(`${name}: ${count} 件${DRY_RUN ? 'が該当' : 'を書き換え'}`);
     total += count;
 });
 
 print(`合計 ${total} 件`);
 
-// 残っていないことを確認する
-let remaining = 0;
-collections.forEach(name => {
-    db.getCollection(name).find({}).forEach(doc => {
-        if (EJSON.stringify(doc).indexOf(OLD) !== -1) {
-            remaining++;
-        }
+// 残っていないことを確認する。書き換えたつもりで実際には効いていない事故を防ぐため、
+// 件数の報告だけで終わらせない。
+if (!DRY_RUN) {
+    let remaining = 0;
+    collections.forEach(name => {
+        db.getCollection(name).find({}).forEach(doc => {
+            if (serialize(doc).indexOf(OLD) !== -1) {
+                remaining++;
+            }
+        });
     });
-});
-print(remaining === 0 ? '旧バケット名の残留なし' : `警告: ${remaining} 件が未置換のまま残っている`);
+    print(remaining === 0 ? '旧バケット名の残留なし' : `警告: ${remaining} 件が未置換のまま残っている`);
+}

--- a/tools/rewrite_image_urls.js
+++ b/tools/rewrite_image_urls.js
@@ -1,0 +1,55 @@
+// テーブルデータに直接埋め込まれた画像URLのバケット名を置き換える。
+//
+// アップロードされた画像のURLは https://<bucket>.s3.<region>.amazonaws.com/upload/<name>
+// という形でコンポーネントのデータに保存される。S3のオブジェクトをコピーしても
+// このURLは変わらないため、バケットを移したら書き換えが必要になる。
+//
+// 最終ダンプをリストアするとデータが元に戻るので、カットオーバー時にも再実行すること。
+//
+// 使い方:
+//   mongosh "<uri>" --file rewrite_image_urls.js --eval 'var OLD="旧バケット名", NEW="新バケット名"'
+
+if (typeof OLD === 'undefined' || typeof NEW === 'undefined') {
+    throw new Error('OLD と NEW を --eval で指定すること');
+}
+
+// Extended JSONへの往復で置換する。ObjectIdやDate等のBSON型は $oid / $date 表現に
+// なるため、単純な文字列置換をしても型が壊れない。
+//
+// 再帰的に走査して文字列の葉だけを置き換える方法は使わないこと。mongoshのBSON
+// デシリアライザは別realmのオブジェクトを返すため `value.constructor === Object`
+// による埋め込みドキュメントの判定が常にfalseになり、置換が実行されない。
+function replaceInDocument(doc) {
+    const canonical = EJSON.stringify(doc, null, 0, {relaxed: false});
+    return EJSON.parse(canonical.split(OLD).join(NEW));
+}
+
+const collections = ['tables', 'table_metas', 'components', 'kits'];
+let total = 0;
+
+collections.forEach(name => {
+    const collection = db.getCollection(name);
+    let count = 0;
+    collection.find({}).forEach(doc => {
+        if (EJSON.stringify(doc).indexOf(OLD) === -1) {
+            return;
+        }
+        collection.replaceOne({_id: doc._id}, replaceInDocument(doc));
+        count++;
+    });
+    print(`${name}: ${count} 件を書き換え`);
+    total += count;
+});
+
+print(`合計 ${total} 件`);
+
+// 残っていないことを確認する
+let remaining = 0;
+collections.forEach(name => {
+    db.getCollection(name).find({}).forEach(doc => {
+        if (EJSON.stringify(doc).indexOf(OLD) !== -1) {
+            remaining++;
+        }
+    });
+});
+print(remaining === 0 ? '旧バケット名の残留なし' : `警告: ${remaining} 件が未置換のまま残っている`);


### PR DESCRIPTION
ECS on EC2構成は再デプロイができない状態にある（LaunchConfigurationの新規作成停止、rexray/ebsの開発終了、AMIの固定）。Fargateへ移行してこれらを一掃する。

新スタックは別AWSアカウント（744617283020）に既にデプロイ済みで、`https://next.asobann.yattom.jp` で動作確認まで完了している。本番（`asobann.yattom.jp`）には未接続。

## 追加したもの

### `aws/fargate.yaml`

- **単一ファイル構成**。mongo・redis・EC2クラスタが不要になり対象が1サービスだけになるため、ネストスタックの利点がなくなった。`cloudformation package` も不要になる
- VPCはパブリックサブネットのみ。NAT Gatewayを置かず追加費用（月$30〜40）を避ける
- タスク1つ、Redisなし。socket.ioのメッセージキューが唯一の用途のため
- `MONGODB_URI` は SSM Parameter Store の SecureString から `Secrets` で注入
- `Command` でイメージの `CMD` を上書きし、キット初期化を回避。起動のたびにDBの `kits` を上書きし、イメージに無いキットを消してしまうため
- `AWS_KEY` / `AWS_SECRET` に空文字を渡す。boto3が明示指定とみなさず既定の認証チェーンにフォールバックするため、**静的キーなしでタスクロールが効く**（イメージ内および実環境で動作確認済み）
- `EnableExecuteCommand: true`。旧構成でホストへ入る手段が全滅した反省

### `tools/dump_mongodb.sh`

本番MongoDBのダンプ取得。SSHもSSMも使えないため、mongoタスクの動的hostPortに対してセキュリティグループを一時開放し、`trap` で必ず閉じる。

### `tools/rewrite_image_urls.js`

画像URLがDBに絶対URLで保存されている（tables 50件 + components 125件）ため、バケット移動時に書き換える。詳細は asobann_app#124。

EJSONの往復で置換している。mongoshのBSONオブジェクトは `constructor === Object` が常にfalseになり、再帰走査では埋め込みドキュメントに入れないため。

## 既存テンプレートの修正

本番のデプロイ済みテンプレートと食い違っていた4箇所を実態に合わせた。2022年のデプロイがコミットされないまま適用されていた。

| 箇所 | 修正前 | 修正後 |
|---|---|---|
| `service/mongodb.yaml` | `mongo:latest` | `mongo:5` |
| `cluster.yaml` | `ami-007cd1678c6286a05` | `ami-03dbf0c122cb6cf1d` |
| `service/app.yaml` | `NAME:` ×10 | `Name:` ×10 |
| `service/mongodb.yaml` | `AutoProvision` | `Autoprovision` |

最後の1件は CloudFormation の正しいプロパティ名がpの小文字であり、**このままではデプロイが通らなかった**。

## 検証済み

| 項目 | 結果 |
|---|---|
| HTTPS / ACM証明書 | OK |
| WebSocket over TLS（ALB経由） | 成立 |
| `come by table` → `load table` | 1,107コンポーネント |
| 画像アップロード（タスクロール経由） | 成功 |

## 関連

決定の経緯は devenv リポジトリの ADR 0002〜0007 に記録してある。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M6RDF9qdJ5cfsx2bcEgko6