### PR TITLE
CIを追加しCloudFormationテンプレートをcfn-lintで検査する

### DIFF
--- a/.cfnlintrc.yaml
+++ b/.cfnlintrc.yaml
@@ -3,11 +3,10 @@
 # ローカル実行:
 #   pip install cfn-lint==1.54.0 && cfn-lint
 
+# 再帰グロブにする。既存の階層を名指しすると、新しいディレクトリに置いた
+# テンプレートが黙って検査対象から外れ、そのこと自体に誰も気づかない。
 templates:
-  - aws/asobann_aws.yaml
-  - aws/fargate.yaml
-  - aws/templates/*.yaml
-  - aws/templates/service/*.yaml
+  - aws/**/*.yaml
 
 ignore_checks:
   # W3002: TemplateURL がローカルパスなので `package` が必要、という警告。

--- a/.cfnlintrc.yaml
+++ b/.cfnlintrc.yaml
@@ -1,0 +1,16 @@
+# cfn-lint の設定。CIとローカルで同じ結果になるよう、対象と除外をここに書く。
+#
+# ローカル実行:
+#   pip install cfn-lint==1.54.0 && cfn-lint
+
+templates:
+  - aws/asobann_aws.yaml
+  - aws/fargate.yaml
+  - aws/templates/*.yaml
+  - aws/templates/service/*.yaml
+
+ignore_checks:
+  # W3002: TemplateURL がローカルパスなので `package` が必要、という警告。
+  # 旧構成のネストスタックは意図的にそう書いており、デプロイ時に package する。
+  # 指摘そのものは正しいが恒常的に出るため、他の警告を埋もれさせないよう除外する。
+  - W3002

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,4 +26,8 @@ jobs:
       # 警告では落とさずエラーだけで落とす。旧EC2構成には移行完了まで解消しない
       # 警告（LaunchConfigurationが保守モード等）が残っており、それで恒常的に
       # 赤くなると、本当に見るべきエラーが埋もれるため。
+      #
+      # 現在の警告はすべて旧構成に由来する。Fargateへのカットオーバー後に
+      # 旧テンプレートを削除したら警告はゼロになるはずなので、その時点で
+      # --non-zero-exit-code warning に引き上げること。
       - run: cfn-lint --non-zero-exit-code error

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  cfn-lint:
+    name: CloudFormation テンプレートの検査
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      # 再現性のためバージョンを固定する。更新するときは手元で通してから上げること。
+      - run: pip install cfn-lint==1.54.0
+
+      # 対象と除外は .cfnlintrc.yaml に書いてあるので引数を渡さない。
+      # 警告では落とさずエラーだけで落とす。旧EC2構成には移行完了まで解消しない
+      # 警告（LaunchConfigurationが保守モード等）が残っており、それで恒常的に
+      # 赤くなると、本当に見るべきエラーが埋もれるため。
+      - run: cfn-lint --non-zero-exit-code error


### PR DESCRIPTION
このリポジトリには**自動で走る検査が何も無い**。その結果として、`DockerVolumeConfiguration` の `Autoprovision` を `AutoProvision` と綴った誤りが数年間残っていた。正しいプロパティ名はpが小文字で、**この状態ではデプロイが通らない**。#6 でデプロイ済みテンプレートと突き合わせて偶然見つかったもので、そうでなければ再デプロイを試みるまで気づけなかった。

`cfn-lint` はこれを検出できる。

```
E3002 Additional properties are not allowed (AutoProvision was unexpected. Did you mean Autoprovision?)
```

人間が思い出さなくても毎回走る場所に置くことで、同種の誤りが埋もれないようにする。

## 追加したもの

### `.github/workflows/ci.yml`

- `push`（master）と `pull_request` で実行
- cfn-lint のバージョンを固定（再現性のため）
- **`--non-zero-exit-code error` で、警告では落とさない**

警告で落とさない理由は、旧EC2構成に移行完了まで解消しない警告が残っているため。

| 警告 | 箇所 |
|---|---|
| W3697 `LaunchConfiguration` が保守モード | `cluster.yaml` |
| W3045 `AccessControl` がレガシープロパティ | `s3-bucket.yaml` |
| W2001 未使用パラメータ `VpcId` | `service/*.yaml` ×3 |

これで恒常的に赤くなると、**本当に見るべきエラーが埋もれる**。いずれも旧構成のもので、カットオーバー後に該当テンプレートごと消える。

### `.cfnlintrc.yaml`

対象と除外を宣言し、CIとローカルで同じ結果が出るようにする。`cfn-lint` を引数なしで叩けば同じ検査ができる。

W3002（`TemplateURL` がローカルパスなので `package` が必要）を除外している。旧構成のネストスタックは意図的にそう書いており、恒常的に出て他の警告を埋もれさせるため。

## 対象にしなかったもの

`tests/test_alive.py` は**Seleniumで稼働中のサイトを叩く**スモークテストで、Firefoxと `deployment_config_local.py` を要求する。毎プッシュのCIには適さない。定期実行や手動実行の枠で別途考えたい。

## 動作確認

| 条件 | 終了コード |
|---|---|
| 現状（警告のみ） | **0** |
| `Autoprovision` を `AutoProvision` に戻す | **2**（E3002を検出） |

意図どおり「エラーで落ちる・警告では落ちない」が成立している。

## 今後

`asobann_app` 側（`pytest` / `npm test` / `npx webpack`）のCIは別PRで。このプロジェクトは2022年から2026年まで停止していた経緯があり、「最後に緑だったのはいつか」が記録に残ること自体に価値がある。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M6RDF9qdJ5cfsx2bcEgko6