### PR TITLE
asobann_appのasyncio移行に追従する（uv・pnpm・ASGI）

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,16 +25,16 @@ Deploy [asobann](https://github.com/yattom/asobann_app) to AWS ECS with CloudFor
    ```shell script
    % cd /path/to/asobann
    % npm install
-   % pip install pipenv
    ```
+
+   Install [uv](https://docs.astral.sh/uv/) for Python dependency management.
 
 1. Build asobann image and push to ECR.
 
    ```shell script
    % cd /path/to/asobann_app
    % npx webpack
-   % pipenv sync
-   % pipenv run pip freeze > requirements.txt
+   % uv export --frozen --no-dev --no-emit-project --no-hashes -o requirements.txt
    % docker build -f Dockerfile.aws -t asobann_aws:latest .
    % docker tag asobann_aws 999999999999.dkr.ecr.REGION.amazonaws.com/asobann_aws
    % aws ecr get-login-password --region REGION | docker login --username AWS --password-stdin \

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Deploy [asobann](https://github.com/yattom/asobann_app) to AWS ECS with CloudFor
 
    ```shell script
    % cd /path/to/asobann
-   % npm install
+   % pnpm install
    ```
 
    Install [uv](https://docs.astral.sh/uv/) for Python dependency management.
@@ -33,7 +33,7 @@ Deploy [asobann](https://github.com/yattom/asobann_app) to AWS ECS with CloudFor
 
    ```shell script
    % cd /path/to/asobann_app
-   % npx webpack
+   % pnpm exec webpack
    % uv export --frozen --no-dev --no-emit-project --no-hashes -o requirements.txt
    % docker build -f Dockerfile.aws -t asobann_aws:latest .
    % docker tag asobann_aws 999999999999.dkr.ecr.REGION.amazonaws.com/asobann_aws
@@ -112,7 +112,7 @@ I set and use shell aliases like this:
 alias build_aws=' \
   # run from asobann_app dir
   set -x ; \
-  npx watch ; \
+  pnpm exec webpack ; \
   docker build -f Dockerfile.aws -t asobann_aws:latest . ; \
   docker tag asobann_aws 999999999999.dkr.ecr.us-east-1.amazonaws.com/asobann_aws ; \
   aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin 999999999999.dkr.ecr.us-east-1.amazonaws.com/asobann_aws ; \

--- a/aws/fargate.yaml
+++ b/aws/fargate.yaml
@@ -342,13 +342,13 @@ Resources:
         - Name: app
           Image: !Ref AppImage
           Essential: true
-          # イメージのCMDは `python3 -m asobann.deploy ; python3 -m asobann.wsgi` で、
+          # イメージのCMDは `python3 -m asobann.deploy ; python3 -m asobann.asgi` で、
           # 起動のたびにキット初期化がDBを上書きし、イメージに無いキットを消してしまう。
           # 初期化を実行しないよう上書きする（ADR 0007）
           Command:
             - python3
             - -m
-            - asobann.wsgi
+            - asobann.asgi
           PortMappings:
             - ContainerPort: 5000
               Protocol: tcp

--- a/docs/aws-architecture.md
+++ b/docs/aws-architecture.md
@@ -42,7 +42,7 @@ asobann_aws.yaml
 
 1. asobann_appでイメージビルド（`npx webpack` → `pipenv requirements > requirements.txt` → `docker build -f Dockerfile.aws`）→ ECRへpush
 2. `aws cloudformation package` でテンプレートをS3へ → `aws cloudformation deploy`
-3. アプリコンテナはCMDで `asobann.deploy`（キット初期データ投入）→ `asobann.wsgi` を実行
+3. アプリコンテナはCMDで `asobann.deploy`（キット初期データ投入）→ `asobann.asgi` を実行
 
 READMEに詳細手順があるが、`cd aws_dev` は現在の `aws/` ディレクトリの旧名なので読み替えること。
 

--- a/tools/build_image.sh
+++ b/tools/build_image.sh
@@ -10,7 +10,7 @@
 # ビルドは1回だけ行い、同じdigestを staging → 本番 と昇格させる（ADR 0009）。
 # 本番用に作り直したイメージは、stagingで確認したものとは別物になる。
 #
-# 前提: docker, aws cli, node（npx webpack）, pipenv
+# 前提: docker, aws cli, node（npx webpack）, uv
 #
 # 使い方:
 #   ./build_image.sh            # ビルドのみ
@@ -50,10 +50,10 @@ echo "$TAG"
 
 echo "==> 依存を書き出す"
 
-# Dockerfile.aws は requirements.txt を COPY する。Pipfile.lock が正で、
+# Dockerfile.aws は requirements.txt を COPY する。uv.lock が正で、
 # requirements.txt はその都度生成する中間物（gitignore済み）。
-pipenv requirements > requirements.txt
-echo "$(grep -c . requirements.txt) パッケージ"
+uv export --frozen --no-dev --no-emit-project --no-hashes -o requirements.txt --quiet
+echo "$(grep -cE '^[a-zA-Z0-9]' requirements.txt) パッケージ"
 
 echo "==> フロントエンドをビルドする"
 

--- a/tools/build_image.sh
+++ b/tools/build_image.sh
@@ -10,7 +10,7 @@
 # ビルドは1回だけ行い、同じdigestを staging → 本番 と昇格させる（ADR 0009）。
 # 本番用に作り直したイメージは、stagingで確認したものとは別物になる。
 #
-# 前提: docker, aws cli, node（npx webpack）, uv
+# 前提: docker, aws cli, node + pnpm, uv
 #
 # 使い方:
 #   ./build_image.sh            # ビルドのみ
@@ -60,13 +60,13 @@ echo "==> フロントエンドをビルドする"
 # webpackの出力先は src/asobann/app/static/ で、これを Dockerfile.aws が
 # src ごと COPY する。つまりビルド順序に依存がある（webpack → docker build）。
 #
-# node_modules があっても必ず npm ci する。ここを「無ければ入れる」にすると、
-# 手元に残った別ブランチのnode_modulesでビルドしてしまう。実際に2026-08-09時点で
+# node_modules があっても必ず frozen-lockfile で入れ直す。ここを「無ければ入れる」に
+# すると、手元に残った別ブランチのnode_modulesでビルドしてしまう。実際に2026-08-09時点で
 # 手元にはslowness_issueブランチのもの（webpack 5.93 / socket.io-client 4.7.5）が
 # 残っており、masterのlock（5.72.1 / 4.5.1）と食い違っていた。
-# npm ci は node_modules を捨ててlockどおりに入れ直す。
-npm ci
-npx webpack
+# pnpm install --frozen-lockfile はlockと不一致なら失敗し、node_modulesをlockどおりに揃える。
+pnpm install --frozen-lockfile
+pnpm exec webpack
 
 echo "==> イメージをビルドする"
 

--- a/tools/smoke_test_image.sh
+++ b/tools/smoke_test_image.sh
@@ -47,7 +47,7 @@ docker run -d --name smoke-app --network "$NETWORK" -p "$PORT:5000" \
   -e PUBLIC_HOSTNAME=localhost \
   -e GOOGLE_ANALYTICS_ID= \
   -e UPLOADED_IMAGE_STORE=local \
-  "$IMAGE" python3 -m asobann.wsgi >/dev/null
+  "$IMAGE" python3 -m asobann.asgi >/dev/null
 
 echo "==> 応答を確かめる"
 


### PR DESCRIPTION
asobann_app 側のモダナイズ（asobann/asobann_app#130）に追従する変更。既に本番へデプロイ済みで、稼働している内容をmasterに反映する。

## 変更

- イメージビルドの依存書き出しを pipenv から uv へ（`e1f654a`）。`Dockerfile.aws` が COPY する `requirements.txt` を `uv export --frozen` で生成する
- パッケージマネージャの手順を npm から pnpm へ更新（`a021141`）
- 本番タスク定義とスモークテストの Command を `asobann.wsgi` → `asobann.asgi` へ（`882b924`）。eventlet/WSGI から Quart/ASGI への移行に対応する

## 確認状況

staging・本番ともデプロイ済み。

masterはこのブランチに対して0コミット先行のため、fast-forwardでマージできる。
