### PR TITLE
R3計測のためstagingをCPU512/メモリ1024にする

### DIFF
--- a/tools/environments.py
+++ b/tools/environments.py
@@ -52,8 +52,10 @@ ENVIRONMENTS = {
         # 較正用のstagingにはGAタグを出さない(本番の計測を汚さない)。
         'google_analytics_id': '',
         'certificate_id': '0767b27e-9973-433c-8a75-11415fd6bc61',
-        'task_cpu': '256',
-        'task_memory': '512',
+        # R3計測(CPU512): Fargateは512 CPUに512MBを組み合わせられないため、
+        # メモリも1024に上げる(負荷が18.4%で一定だった=メモリ不足が理由ではない)。
+        'task_cpu': '512',
+        'task_memory': '1024',
         'app_task_count': '1',
     },
     'prod': {


### PR DESCRIPTION
## Summary
- CPU256での分散負荷試験(n2/n6/n10/n14)で、n10で既にCPU平均92%・最大99%とほぼ天井、n14では実際にworkerが脱落しp95が202ms→294msへ跳ね上がる飽和を確認できた
- この次の段階として、CPUを2倍にしたときに捌ける人数がどう伸びるかをR3として測定する
- Fargateは512 CPUに512MBを組み合わせられないため、メモリも1024に上げる(負荷は終始18.4%で一定だったので、メモリ不足が理由ではない)

## Test plan
- [x] staging(prod)ブロックの値は変更していないことをdiffで確認
- [ ] `inv deploy --env=staging`で反映し、タスク定義にCpu=512/Memory=1024が入ることを確認