### PR TITLE
asobann.yattom.jp のホストゾーンを新アカウントの独立スタックへ移す

### DIFF
--- a/aws/dns.yaml
+++ b/aws/dns.yaml
@@ -1,0 +1,116 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: >
+  asobann.yattom.jp のDNS。2026-08-20に旧アカウント550251267268から移した。
+
+  本番(asobann-fargate)とstaging(asobann-staging)でホストゾーンを共有するため、
+  どちらのアプリスタックにも入れず独立させてある。旧環境では apex のAレコードが
+  asobann-prod の LoadBalancer ネストスタックの持ち物になっており、旧環境を撤去
+  しようとすると本番ドメインが道連れになる状態だった。同じ轍を踏まないための分離。
+
+  親ドメイン yattom.jp はAWSの外にある。レジストラ兼DNSホストは Squarespace
+  (旧Google Domains。ネームサーバは ns-cloud-a1..a4.googledomains.com のまま)。
+  このゾーンを作り直してNSが変わったら、Squarespaceの管理画面で yattom.jp の
+  asobann NSレコードを手で差し替えないとドメイン全体が引けなくなる。
+  HostedZone に Retain を付けてあるのはそのため。
+
+Parameters:
+  ProdStackName:
+    Type: String
+    Default: asobann-fargate
+    Description: 本番のALBを持つスタック名。Outputsをここから取り込む
+
+  StagingStackName:
+    Type: String
+    Default: asobann-staging
+    Description: stagingのALBを持つスタック名
+
+  AcmValidationRecordName:
+    Type: String
+    Default: _b536a27881f6b7986cdb9ab6c3c30ea2.asobann.yattom.jp.
+    Description: >
+      ACM証明書(environments.py の certificate_id)のDNS検証用CNAME名。
+      これが引けないと証明書の自動更新が失敗する
+
+  AcmValidationRecordValue:
+    Type: String
+    Default: _f8ce04c42cf4894a5f07ade3ecc2caea.jkddzztszm.acm-validations.aws.
+    Description: 上のCNAMEの値
+
+Resources:
+  # ゾーンを作り直すとNSが変わり、親ゾーン(yattom.jp / Squarespace)側の
+  # 委譲レコードを人手で直すまでドメイン全体が引けなくなる。だから置換も削除も
+  # させない。
+  HostedZone:
+    Type: AWS::Route53::HostedZone
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    Properties:
+      Name: asobann.yattom.jp
+      HostedZoneConfig:
+        Comment: asobann 本番DNS
+
+  # 以下のレコードは DeletionPolicy のみ Retain にしてある。スタックを消しても
+  # サイトが落ちないようにするのが目的。UpdateReplacePolicy は既定(Delete)のまま。
+  # レコードの置換時に旧レコードを残すと同名レコードが衝突するため。
+  ApexRecord:
+    Type: AWS::Route53::RecordSet
+    DeletionPolicy: Retain
+    Properties:
+      HostedZoneId: !Ref HostedZone
+      Name: asobann.yattom.jp.
+      Type: A
+      AliasTarget:
+        DNSName:
+          Fn::ImportValue: !Sub "${ProdStackName}-LoadBalancerDnsName"
+        HostedZoneId:
+          Fn::ImportValue: !Sub "${ProdStackName}-LoadBalancerHostedZoneId"
+        EvaluateTargetHealth: false
+
+  NextRecord:
+    Type: AWS::Route53::RecordSet
+    DeletionPolicy: Retain
+    Properties:
+      HostedZoneId: !Ref HostedZone
+      Name: next.asobann.yattom.jp.
+      Type: A
+      AliasTarget:
+        DNSName:
+          Fn::ImportValue: !Sub "${ProdStackName}-LoadBalancerDnsName"
+        HostedZoneId:
+          Fn::ImportValue: !Sub "${ProdStackName}-LoadBalancerHostedZoneId"
+        EvaluateTargetHealth: false
+
+  StagingRecord:
+    Type: AWS::Route53::RecordSet
+    DeletionPolicy: Retain
+    Properties:
+      HostedZoneId: !Ref HostedZone
+      Name: staging.asobann.yattom.jp.
+      Type: A
+      AliasTarget:
+        DNSName:
+          Fn::ImportValue: !Sub "${StagingStackName}-LoadBalancerDnsName"
+        HostedZoneId:
+          Fn::ImportValue: !Sub "${StagingStackName}-LoadBalancerHostedZoneId"
+        EvaluateTargetHealth: false
+
+  AcmValidationRecord:
+    Type: AWS::Route53::RecordSet
+    DeletionPolicy: Retain
+    Properties:
+      HostedZoneId: !Ref HostedZone
+      Name: !Ref AcmValidationRecordName
+      Type: CNAME
+      TTL: 300
+      ResourceRecords:
+        - !Ref AcmValidationRecordValue
+
+Outputs:
+  HostedZoneId:
+    Value: !Ref HostedZone
+
+  NameServers:
+    Description: >
+      親ゾーン yattom.jp (Squarespace) の asobann NSレコードに設定する値。
+      ここを差し替えるまで、このゾーンは誰からも参照されない
+    Value: !Join [", ", !GetAtt HostedZone.NameServers]

--- a/aws/fargate.yaml
+++ b/aws/fargate.yaml
@@ -412,13 +412,20 @@ Resources:
 
 
 Outputs:
+  # dns.yaml が Fn::ImportValue で取り込む。スタック名を前置するのは、この
+  # テンプレートを本番(asobann-fargate)とstaging(asobann-staging)の両方で
+  # 使っており、Export名はアカウント内で一意でなければならないため。
   LoadBalancerDnsName:
     Description: Route53のALIASレコードの向き先に指定する値
     Value: !GetAtt LoadBalancer.DNSName
+    Export:
+      Name: !Sub "${AWS::StackName}-LoadBalancerDnsName"
 
   LoadBalancerHostedZoneId:
     Description: ALIASレコード作成時に必要なホストゾーンID
     Value: !GetAtt LoadBalancer.CanonicalHostedZoneID
+    Export:
+      Name: !Sub "${AWS::StackName}-LoadBalancerHostedZoneId"
 
   ImageBucketName:
     Description: 旧アカウントのバケットから中身を同期する先


### PR DESCRIPTION
## 何をしたか

`asobann.yattom.jp` のホストゾーンを旧アカウント 550251267268 から新アカウント 744617283020 へ移し、その構成を `aws/dns.yaml` として定義した。**適用済み**（スタック名 `asobann-dns`）。

## なぜ

旧本番環境（550側の `asobann-prod` スタック）を撤去したいが、調べたところ **apex の A レコード `asobann.yattom.jp` が `asobann-prod` の LoadBalancer ネストスタックの持ち物**だった。レコードの中身は新アカウントのALBに手で書き換えられていたが、CloudFormation は所有者のままなので、**旧スタックを消すと本番ドメインが道連れになる**状態だった。

DNSを先に新アカウントへ移すことで、旧ゾーンが誰からも参照されなくなってから旧スタックを消せる。`DeletionPolicy: Retain` を旧スタックに後付けする小細工が不要になる。

## 設計

**アプリのスタックに入れず独立させた。** ホストゾーンは本番とstagingの共有物なので、そもそもどちらか一方のアプリスタックに属するのがおかしい。旧環境の構成がまさにその失敗例だった。

**Retain の付け方を2種類に分けている。**

| リソース | DeletionPolicy | UpdateReplacePolicy | 理由 |
|---|---|---|---|
| `HostedZone` | Retain | Retain | 作り直すとNSが変わり、親ドメイン側の委譲レコードを手で直すまでドメイン全体が引けなくなる |
| 各 RecordSet | Retain | 既定(Delete) | 狙いは「スタックを消してもサイトが落ちない」ことなので削除時だけで足りる。置換時まで Retain にすると旧レコードが残って同名衝突する |

**ALBの向き先はハードコードせず `Fn::ImportValue`。** そのために `fargate.yaml` の Outputs に Export 名を追加した。テンプレート1枚を本番とstagingで使い回しており Export 名はアカウント内で一意でなければならないため `${AWS::StackName}` を前置している。

**ACM検証CNAMEを含めてある。** これが引けないと証明書の自動更新が失敗する。旧証明書用の検証CNAMEは旧環境と一緒に用済みなので持ってきていない。

## 親ドメインについて

`yattom.jp` はAWSの外にある。**レジストラ兼DNSホストは Squarespace**（旧Google Domains。ネームサーバは `ns-cloud-a1..a4.googledomains.com` のまま）。`asobann` の NS 委譲レコードはSquarespaceの管理画面で手作業で変える。テンプレートのコメントに書いてある。

## 適用と検証

`fargate.yaml` の変更は**リソースを一切変えない**。変更セットが `Changes: []` であることを確認してから staging → 本番の順にデプロイした（イメージタグは現行の `deb637c` のまま）。

DNS切替後の確認:

| 項目 | 結果 |
|---|---|
| 委譲NS | 新しい4本に切替済み |
| `asobann.yattom.jp` / `next.` | 50.17.144.100, 54.236.244.75（本番ALB） |
| `staging.` | 100.49.247.96, 32.198.143.246（staging ALB） |
| ACM検証CNAME | 解決OK |
| HTTPS | HTTP 302、証明書検証OK |

新旧ゾーンが同じ答えを返す状態で切り替えたので、切替中も無停止。

## 残作業（このPRの範囲外）

委譲NSのTTL（21600秒）が抜けるのを待ってから、旧アカウントの撤去を行う。

- prod の S3バケットを空にして `asobann-prod` を削除（画像140個は新アカウントへコピー済み・完全一致を確認）
- dev の S3バケットを空にして `asobann-dev` を削除（2024-08-04からS3が空でないため DELETE_FAILED のまま止まっている）
- 旧ホストゾーンを削除

旧アカウントの月$33.83のうち$29ほどが減る見込み。

なお `dns.yaml` のデプロイは `inv` タスクに載せていない（生の `aws cloudformation deploy` で流した）。滅多に触らないスタックなので不要と判断した。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NvGQdzYZWL666uXApy4b7b
