### PR TITLE
dns.yamlからアプリスタックへの依存を消す(#180 PR-A)

### DIFF
--- a/aws/dns.yaml
+++ b/aws/dns.yaml
@@ -14,16 +14,6 @@ Description: >
   HostedZone に Retain を付けてあるのはそのため。
 
 Parameters:
-  ProdStackName:
-    Type: String
-    Default: asobann-fargate
-    Description: 本番のALBを持つスタック名。Outputsをここから取り込む
-
-  StagingStackName:
-    Type: String
-    Default: asobann-staging
-    Description: stagingのALBを持つスタック名
-
   AcmValidationRecordName:
     Type: String
     Default: _b536a27881f6b7986cdb9ab6c3c30ea2.asobann.yattom.jp.
@@ -49,51 +39,6 @@ Resources:
       HostedZoneConfig:
         Comment: asobann 本番DNS
 
-  # 以下のレコードは DeletionPolicy のみ Retain にしてある。スタックを消しても
-  # サイトが落ちないようにするのが目的。UpdateReplacePolicy は既定(Delete)のまま。
-  # レコードの置換時に旧レコードを残すと同名レコードが衝突するため。
-  ApexRecord:
-    Type: AWS::Route53::RecordSet
-    DeletionPolicy: Retain
-    Properties:
-      HostedZoneId: !Ref HostedZone
-      Name: asobann.yattom.jp.
-      Type: A
-      AliasTarget:
-        DNSName:
-          Fn::ImportValue: !Sub "${ProdStackName}-LoadBalancerDnsName"
-        HostedZoneId:
-          Fn::ImportValue: !Sub "${ProdStackName}-LoadBalancerHostedZoneId"
-        EvaluateTargetHealth: false
-
-  NextRecord:
-    Type: AWS::Route53::RecordSet
-    DeletionPolicy: Retain
-    Properties:
-      HostedZoneId: !Ref HostedZone
-      Name: next.asobann.yattom.jp.
-      Type: A
-      AliasTarget:
-        DNSName:
-          Fn::ImportValue: !Sub "${ProdStackName}-LoadBalancerDnsName"
-        HostedZoneId:
-          Fn::ImportValue: !Sub "${ProdStackName}-LoadBalancerHostedZoneId"
-        EvaluateTargetHealth: false
-
-  StagingRecord:
-    Type: AWS::Route53::RecordSet
-    DeletionPolicy: Retain
-    Properties:
-      HostedZoneId: !Ref HostedZone
-      Name: staging.asobann.yattom.jp.
-      Type: A
-      AliasTarget:
-        DNSName:
-          Fn::ImportValue: !Sub "${StagingStackName}-LoadBalancerDnsName"
-        HostedZoneId:
-          Fn::ImportValue: !Sub "${StagingStackName}-LoadBalancerHostedZoneId"
-        EvaluateTargetHealth: false
-
   AcmValidationRecord:
     Type: AWS::Route53::RecordSet
     DeletionPolicy: Retain
@@ -108,6 +53,8 @@ Resources:
 Outputs:
   HostedZoneId:
     Value: !Ref HostedZone
+    Export:
+      Name: asobann-dns-HostedZoneId
 
   NameServers:
     Description: >

--- a/aws/fargate.yaml
+++ b/aws/fargate.yaml
@@ -412,9 +412,10 @@ Resources:
 
 
 Outputs:
-  # dns.yaml が Fn::ImportValue で取り込む。スタック名を前置するのは、この
-  # テンプレートを本番(asobann-fargate)とstaging(asobann-staging)の両方で
-  # 使っており、Export名はアカウント内で一意でなければならないため。
+  # Route53のALIASレコードから参照するためのExport(現時点でimport元はない)。
+  # スタック名を前置するのは、このテンプレートを本番(asobann-fargate)と
+  # staging(asobann-staging)の両方で使っており、Export名はアカウント内で
+  # 一意でなければならないため。
   LoadBalancerDnsName:
     Description: Route53のALIASレコードの向き先に指定する値
     Value: !GetAtt LoadBalancer.DNSName


### PR DESCRIPTION
## 何のためのPRか

#180 の設計に基づく PR-A。`asobann-staging` を削除・再作成できるようにするための1歩目として、`dns.yaml` が `asobann-fargate` / `asobann-staging` のExportをimportしている状態を解消する。CloudFormationは、Exportが他スタックからimportされている間、producerスタック（アプリスタック側）を削除できない。

## 変更内容

- `ApexRecord` / `NextRecord` / `StagingRecord` を削除。使わなくなったパラメータ `ProdStackName` / `StagingStackName` も削除
- `HostedZoneId` Outputに `Export: asobann-dns-HostedZoneId` を追加（次のPRで `fargate.yaml` 側がこのホストゾーンを引くために使う）

`next.asobann.yattom.jp` はFargate移行のカットオーバー用に作った一時的な名前で、切り替え完了後は参照ゼロの残骸なのであわせて削除する。

## このPRの範囲外

- Route53の実レコードはこのPRでは触らない。対象レコードは `DeletionPolicy: Retain` のままなので、テンプレートから消してもRoute53には残り、名前解決は変わらない
- 各アプリスタック側にAレコードを持たせる変更（`fargate.yaml` への `DnsRecord` 追加、ALB Exportの削除）は次のPR（issueのPR-B）で行う
- teardownコマンドの実装（issueのPR-C）も別PR

## 適用順序について

issue #180に記載の通り、CloudFormationは他スタックからimportされているExportを削除できない。このPRを先に適用してdns.yamlからのimportを全部外してから、PR-Bで`fargate.yaml`側のExportを削除する必要がある。

参照: #180（issue自体はPR-B・PR-Cの完了までクローズしない。このPRは自動クローズしない書き方にしてある）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011DosPjtrhtLBw6nzwSVgLU