### PR TITLE
fargate.yamlにDnsRecordを追加、ALB Exportを削除(#180 PR-B)

### DIFF
--- a/aws/fargate.yaml
+++ b/aws/fargate.yaml
@@ -228,7 +228,7 @@ Resources:
     Type: AWS::Route53::RecordSet
     Properties:
       HostedZoneId: !ImportValue asobann-dns-HostedZoneId
-      Name: !Sub "${PublicHostname}."
+      Name: !Ref PublicHostname
       Type: A
       AliasTarget:
         DNSName: !GetAtt LoadBalancer.DNSName

--- a/aws/fargate.yaml
+++ b/aws/fargate.yaml
@@ -4,7 +4,10 @@ Description: >
   asobann on ECS Fargate.
   ADR 0004 に基づき、ECS on EC2 から Fargate へ移行するための構成。
   MongoDB は Atlas を使うため、このスタックはデータストアを持たない（ADR 0003）。
-  Route53レコードとACM証明書は別アカウントのホストゾーンに関わるため、このスタックの外で扱う。
+  ホストゾーンとACM証明書は asobann-dns スタックが持つ（#180）。このスタックは
+  asobann-dns の HostedZoneId をImportValueで参照し、自分のホスト名のAレコードを
+  自分で持つ。ACM証明書自体はCertificateArnパラメータで受け取るだけで、証明書の
+  発行・検証はこのスタックの外で扱う。
 
   デプロイ例（タグはスタック単位で付けると対応リソースへ自動で伝播する）:
     aws cloudformation deploy --template-file aws/fargate.yaml --stack-name asobann-fargate \

--- a/aws/fargate.yaml
+++ b/aws/fargate.yaml
@@ -222,6 +222,19 @@ Resources:
         - Type: forward
           TargetGroupArn: !Ref TargetGroup
 
+  # DeletionPolicyを付けない(既定のDelete)。スタックを消せばレコードも消える、
+  # というのが#180の設計そのもの。ホストゾーンはasobann-dns側でRetainしてある。
+  DnsRecord:
+    Type: AWS::Route53::RecordSet
+    Properties:
+      HostedZoneId: !ImportValue asobann-dns-HostedZoneId
+      Name: !Sub "${PublicHostname}."
+      Type: A
+      AliasTarget:
+        DNSName: !GetAtt LoadBalancer.DNSName
+        HostedZoneId: !GetAtt LoadBalancer.CanonicalHostedZoneID
+        EvaluateTargetHealth: false
+
   # ---------------------------------------------------------------- 画像アップロード先
   # 2023年4月以降に作られるバケットは既定でACLが無効。アプリは public-read ACL を
   # 付けてアップロードするため、明示的にACLを有効化する必要がある。
@@ -412,21 +425,13 @@ Resources:
 
 
 Outputs:
-  # Route53のALIASレコードから参照するためのExport(現時点でimport元はない)。
-  # スタック名を前置するのは、このテンプレートを本番(asobann-fargate)と
-  # staging(asobann-staging)の両方で使っており、Export名はアカウント内で
-  # 一意でなければならないため。
   LoadBalancerDnsName:
-    Description: Route53のALIASレコードの向き先に指定する値
+    Description: ALB自体のDNS名。DnsRecordがALIASで参照する
     Value: !GetAtt LoadBalancer.DNSName
-    Export:
-      Name: !Sub "${AWS::StackName}-LoadBalancerDnsName"
 
   LoadBalancerHostedZoneId:
-    Description: ALIASレコード作成時に必要なホストゾーンID
+    Description: ALB自体のホストゾーンID。DnsRecordがALIASで参照する
     Value: !GetAtt LoadBalancer.CanonicalHostedZoneID
-    Export:
-      Name: !Sub "${AWS::StackName}-LoadBalancerHostedZoneId"
 
   ImageBucketName:
     Description: 旧アカウントのバケットから中身を同期する先

--- a/aws/fargate.yaml
+++ b/aws/fargate.yaml
@@ -429,11 +429,11 @@ Resources:
 
 Outputs:
   LoadBalancerDnsName:
-    Description: ALB自体のDNS名。DnsRecordがALIASで参照する
+    Description: ALBのDNS名。DnsRecordのAliasTargetに設定する値と同じ
     Value: !GetAtt LoadBalancer.DNSName
 
   LoadBalancerHostedZoneId:
-    Description: ALB自体のホストゾーンID。DnsRecordがALIASで参照する
+    Description: ALBのホストゾーンID。DnsRecordのAliasTargetに設定する値と同じ
     Value: !GetAtt LoadBalancer.CanonicalHostedZoneID
 
   ImageBucketName:


### PR DESCRIPTION
## 内容

issue #180 のPR-B。`asobann-dns` からアプリスタックへの依存を切る(PR-A、#13)のに続いて、逆方向 — アプリスタックが自分のホスト名のAレコードを自分で持つ — の変更。

- `DnsRecord` (Route53 RecordSet) を追加。`asobann-dns` がExportした `HostedZoneId` を `!ImportValue` で参照し、ALBへのALIASレコードを作る。`DeletionPolicy` は付けない(既定のDelete) — スタックを消せばレコードも消えるのが#180の設計そのもの。
- `LoadBalancerDnsName` / `LoadBalancerHostedZoneId` の `Export` を削除。PR-Aで `dns.yaml` 側の `Fn::ImportValue` が無くなったため用途がなくなった。Output自体は `DnsRecord` が同一スタック内で `!GetAtt` として使うため残してある。

## 注意: これだけではまだ適用できない

issue #180のフェーズ2の説明のとおり、このテンプレートを適用すると **同一ゾーン・同一名・同一タイプのAliasレコードが既に存在するため `Tried to create resource record set ... but it already exists` で失敗する**。適用前に該当のRoute53レコードを手で消す必要がある(本番は不通になる時間が生じる)。

このPRはテンプレートの変更のみ。実際の適用(staging→本番の順、ChangeSetの先行作成、レコードの手動削除のタイミング調整)はissue #180のフェーズ2の手順に従って別途行う。

## テスト

- fargate.yamlの構文はテキストとしてレビュー確認(cfn-lint等は本リポジトリの依存関係にないため未実行)
- 実際のCloudFormationへの適用はこのPRの範囲外

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011DosPjtrhtLBw6nzwSVgLU